### PR TITLE
user invite mutation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,26 +1,25 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
-name: Lint, Test, and Build
+name: Lint and Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-  lint-test-build:
+  lint-test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node 22
-      uses: actions/setup-node@v4
-      with:
-        node-version: 22.x
-        cache: 'npm'
-    - run: npm install
-    - run: npm run lint
-    - run: npm test
-    - run: npm run build
+      - uses: actions/checkout@v4
+      - name: Use Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "npm"
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/babel.config.jest.js
+++ b/babel.config.jest.js
@@ -1,1 +1,8 @@
-module.exports = {presets: ["next/babel", "@babel/preset-typescript", "@babel/preset-env"]}
+module.exports = {
+  presets: [
+    "next/babel",
+    "@babel/preset-typescript",
+    "@babel/preset-env",
+    "@babel/preset-react",
+  ],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,10 +7,15 @@ module.exports = {
   },
   setupFilesAfterEnv: ["./src/test/dbMock.ts", "./src/test/authMock.ts"],
   transform: {
-    "^.+\\.(ts|tsx)?$": "ts-jest",
-    "^.+\\.(js|jsx)$": ["babel-jest", { "configFile": "./babel.config.jest.js" }],
+    "^.+\\.(ts|tsx)?$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          jsx: "react-jsx",
+        },
+      },
+    ],
+    "^.+\\.(js|jsx)$": ["babel-jest", { configFile: "./babel.config.jest.js" }],
   },
-  transformIgnorePatterns: [
-    "node_modules/(?!@auth)/"
-  ]
+  transformIgnorePatterns: ["node_modules/(?!@auth)/"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,14 @@
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.4.1",
         "react-icons": "^5.4.0",
+        "uuid": "^11.0.5",
         "zod": "^3.24.1",
         "zod-form-data": "^2.0.5"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
         "@babel/preset-env": "^7.26.0",
+        "@babel/preset-react": "^7.26.3",
         "@babel/preset-typescript": "^7.26.0",
         "@babel/runtime": "^7.26.0",
         "@jest/globals": "^29.7.0",
@@ -1542,6 +1544,71 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.9.tgz",
+      "integrity": "sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
+      "integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/plugin-syntax-jsx": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.25.9.tgz",
+      "integrity": "sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.25.9.tgz",
+      "integrity": "sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
@@ -1867,6 +1934,26 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
+      "integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-transform-react-display-name": "^7.25.9",
+        "@babel/plugin-transform-react-jsx": "^7.25.9",
+        "@babel/plugin-transform-react-jsx-development": "^7.25.9",
+        "@babel/plugin-transform-react-pure-annotations": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-typescript": {
@@ -11868,6 +11955,18 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.4.0",
+    "uuid": "^11.0.5",
     "zod": "^3.24.1",
     "zod-form-data": "^2.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.26.0",
+    "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.26.0",
     "@babel/runtime": "^7.26.0",
     "@jest/globals": "^29.7.0",

--- a/src/app/api/invites/route.test.ts
+++ b/src/app/api/invites/route.test.ts
@@ -118,8 +118,8 @@ test("test email html", async () => {
 
       const uuidMock = jest.spyOn(uuid, "v4");
       const mockToken = "mocked-uuid-token";
-      // Type assertion to fix string/Uint8Array mismatch
-      uuidMock.mockReturnValueOnce(mockToken as any);
+      // @ts-expect-error: jest cannot deal with overloaded functions
+      uuidMock.mockReturnValueOnce(mockToken);
 
       const sendEmailMock = jest.spyOn(emailModule, "sendEmail");
 

--- a/src/app/api/invites/route.test.ts
+++ b/src/app/api/invites/route.test.ts
@@ -1,12 +1,12 @@
 import { testApiHandler } from "next-test-api-route-handler";
-import * as appHandler from "./route";
-import * as emailModule from "@/util/email";
 import { expect, test } from "@jest/globals";
-import { dbMock } from "@/test/dbMock";
-import { authMock } from "@/test/authMock";
 import { UserType } from "@prisma/client";
 import * as uuid from "uuid";
-import openHtml from "open-html";
+
+import * as appHandler from "./route";
+import * as emailModule from "@/util/email";
+import { dbMock } from "@/test/dbMock";
+import { authMock } from "@/test/authMock";
 
 jest.mock("@/util/email");
 
@@ -164,7 +164,7 @@ test("UserInvite expires in one day", async () => {
   });
 });
 
-test("show email", async () => {
+test("verify sendEmail call", async () => {
   await testApiHandler({
     appHandler,
     async test({ fetch }) {
@@ -181,8 +181,7 @@ test("show email", async () => {
       const res = await fetch({ method: "POST", body: formData });
       expect(res.status).toBe(200);
 
-      const emailHtml = sendEmailMock.mock.calls[0][2];
-      openHtml(emailHtml);
+      expect(sendEmailMock).toHaveBeenCalled();
     },
   });
 });

--- a/src/app/api/invites/route.test.ts
+++ b/src/app/api/invites/route.test.ts
@@ -1,0 +1,188 @@
+import { testApiHandler } from "next-test-api-route-handler";
+import * as appHandler from "./route";
+
+import { expect, test } from "@jest/globals";
+import { dbMock } from "@/test/dbMock";
+import { authMock } from "@/test/authMock";
+import { UserType } from "@prisma/client";
+
+jest.mock("@/util/email");
+
+test("requires session", async () => {
+  await testApiHandler({
+    appHandler,
+
+    async test({ fetch }) {
+      const formData = new FormData();
+      formData.append("email", "test@test.com");
+      formData.append("userType", "ADMIN");
+      const res = await fetch({ method: "POST", body: formData });
+      expect(res.status).toBe(401);
+    },
+  });
+});
+
+test("requires SUPER_ADMIN user type", async () => {
+  await testApiHandler({
+    appHandler,
+    async test({ fetch }) {
+      authMock.mockReturnValueOnce({
+        user: { id: "1234", type: "ADMIN" },
+        expires: "",
+      });
+
+      const formData = new FormData();
+      formData.append("email", "test@test.com");
+      formData.append("userType", "ADMIN");
+      const res = await fetch({ method: "POST", body: formData });
+      expect(res.status).toBe(403);
+    },
+  });
+});
+
+test("email is validated correctly", async () => {
+  await testApiHandler({
+    appHandler,
+    async test({ fetch }) {
+      authMock.mockReturnValueOnce({
+        user: { id: "1234", type: "SUPER_ADMIN" },
+        expires: "",
+      });
+
+      const formData = new FormData();
+      formData.append("email", "invalidemail");
+      formData.append("userType", "ADMIN");
+      const res = await fetch({ method: "POST", body: formData });
+      expect(res.status).toBe(400);
+    },
+  });
+});
+
+test("userType is validated correctly", async () => {
+  await testApiHandler({
+    appHandler,
+    async test({ fetch }) {
+      authMock.mockReturnValueOnce({
+        user: { id: "1234", type: "SUPER_ADMIN" },
+        expires: "",
+      });
+
+      const formData = new FormData();
+      formData.append("email", "test@test.com");
+      formData.append("userType", "INVALID_TYPE");
+      const res = await fetch({ method: "POST", body: formData });
+      expect(res.status).toBe(400);
+    },
+  });
+});
+
+test("check existing user", async () => {
+  await testApiHandler({
+    appHandler,
+    async test({ fetch }) {
+      authMock.mockReturnValueOnce({
+        user: { id: "1234", type: "SUPER_ADMIN" },
+        expires: "",
+      });
+
+      dbMock.user.findFirst.mockResolvedValue({
+        id: 1,
+        email: "test@test.com",
+        type: UserType.ADMIN,
+        passwordHash: "abc",
+      });
+
+      const formData = new FormData();
+      formData.append("email", "test@test.com");
+      formData.append("userType", "ADMIN");
+      const res = await fetch({ method: "POST", body: formData });
+      expect(res.status).toBe(409);
+    },
+  });
+});
+
+test("test email html", async () => {
+  await testApiHandler({
+    appHandler,
+    async test({ fetch }) {
+      authMock.mockReturnValueOnce({
+        user: { id: "1234", type: "SUPER_ADMIN" },
+        expires: "",
+      });
+
+      const uuidMock = jest.spyOn(require("uuid"), "v4");
+      const mockToken = "mocked-uuid-token";
+      uuidMock.mockReturnValue(mockToken);
+
+      const formData = new FormData();
+      formData.append("email", "test@test.com");
+      formData.append("userType", "ADMIN");
+      const res = await fetch({ method: "POST", body: formData });
+      expect(res.status).toBe(200);
+
+      const sendEmail = require("@/util/email").sendEmail;
+      const emailHtml = sendEmail.mock.calls[0][2];
+      const urlRegex = new RegExp(`register\\?token=${mockToken}`);
+      expect(emailHtml).toMatch(urlRegex);
+
+      uuidMock.mockRestore();
+    },
+  });
+});
+
+test("UserInvite expires in one day", async () => {
+  await testApiHandler({
+    appHandler,
+    async test({ fetch }) {
+      authMock.mockReturnValueOnce({
+        user: { id: "1234", type: "SUPER_ADMIN" },
+        expires: "",
+      });
+
+      const sendEmailMock = jest.spyOn(require("@/util/email"), "sendEmail");
+
+      const formData = new FormData();
+      formData.append("email", "test@test.com");
+      formData.append("userType", "ADMIN");
+      const res = await fetch({ method: "POST", body: formData });
+      expect(res.status).toBe(200);
+
+      const createdInvite = dbMock.userInvite.create.mock.calls[0][0].data;
+      const expirationDate = new Date(createdInvite.expiration);
+      const currentDate = new Date();
+      const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+
+      expect(expirationDate.getTime() - currentDate.getTime()).toBeCloseTo(
+        oneDayInMilliseconds,
+        -2
+      );
+
+      sendEmailMock.mockRestore();
+    },
+  });
+});
+test("show email", async () => {
+  await testApiHandler({
+    appHandler,
+    async test({ fetch }) {
+      authMock.mockReturnValueOnce({
+        user: { id: "1234", type: "SUPER_ADMIN" },
+        expires: "",
+      });
+
+      const sendEmailMock = jest.spyOn(require("@/util/email"), "sendEmail");
+
+      const formData = new FormData();
+      formData.append("email", "test@test.com");
+      formData.append("userType", "ADMIN");
+      const res = await fetch({ method: "POST", body: formData });
+      expect(res.status).toBe(200);
+
+      const emailHtml = sendEmailMock.mock.calls[0][2];
+      const open = require("open-html");
+      open(emailHtml);
+
+      sendEmailMock.mockRestore();
+    },
+  });
+});

--- a/src/app/api/invites/route.ts
+++ b/src/app/api/invites/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { zfd } from "zod-form-data";
+import { v4 as uuidv4 } from "uuid";
+import { UserType } from "@prisma/client";
+import { render } from "@react-email/render";
+
 import { auth } from "@/auth";
+import { db } from "@/db";
+import { sendEmail } from "@/util/email";
+import UserInviteTemplate from "@/email/UserInviteTemplate";
 import {
   argumentError,
   authenticationError,
@@ -8,13 +16,6 @@ import {
   conflictError,
   ok,
 } from "@/util/responses";
-import { UserType } from "@prisma/client";
-import { db } from "@/db";
-import { v4 as uuidv4 } from "uuid";
-import { sendEmail } from "@/util/email";
-import { render } from "@react-email/render";
-import UserInviteTemplate from "@/email/UserInviteTemplate";
-import { z } from "zod";
 
 const schema = zfd.formData({
   email: zfd.text(z.string().email()),
@@ -22,24 +23,19 @@ const schema = zfd.formData({
 });
 
 /**
- * Handles POST requests for creating user invites
- * @param {NextRequest} request - The incoming request object
- * @returns {Promise<Response>} Response indicating success or failure
- * @throws {Response} 401 if no valid session
- * @throws {Response} 403 if user is not SUPER_ADMIN
- * @throws {Response} 400 if form data is invalid
- * @throws {Response} 409 if email is already registered
- *
- * This endpoint:
- * 1. Validates the user has SUPER_ADMIN privileges
- * 2. Validates the email and userType from form data
- * 3. Checks if email is already registered
- * 4. Creates a new user invite with 24 hour expiration
- * 5. Sends invite email with registration link
+ * Create a new user invite (expires in 1 day) and sends email to user.
+ * Parameters are passed via form data.
+ * @params email Email address to send the invite to
+ * @params userType Type of user to create (ADMIN, etc.)
+ * @returns 401 if no valid session
+ * @returns 403 if session user is not SUPER_ADMIN
+ * @returns 400 if form data is invalid
+ * @returns 409 if email is already registered
+ * @returns 200 if invite was created successfully
  */
 export async function POST(request: NextRequest) {
   const session = await auth();
-  if (!session) return authenticationError("Session required");
+  if (!session?.user) return authenticationError("Session required");
 
   if (session.user.type !== UserType.SUPER_ADMIN) {
     return authorizationError("You are not allowed to create an invite");
@@ -47,13 +43,12 @@ export async function POST(request: NextRequest) {
 
   const formData = await request.formData();
   let email, userType;
-  try {
-    const parsedData = schema.parse(formData);
-    email = parsedData.email;
-    userType = parsedData.userType;
-  } catch {
+  const parsedData = schema.safeParse(formData);
+  if (!parsedData.success) {
     return argumentError("Invalid form data");
   }
+  email = parsedData.data.email;
+  userType = parsedData.data.userType;
 
   const existingUser = await db.user.findFirst({ where: { email } });
   if (existingUser) {

--- a/src/app/api/invites/route.ts
+++ b/src/app/api/invites/route.ts
@@ -42,13 +42,11 @@ export async function POST(request: NextRequest) {
   }
 
   const formData = await request.formData();
-  let email, userType;
-  const parsedData = schema.safeParse(formData);
-  if (!parsedData.success) {
+  const parseResult = schema.safeParse(formData);
+  if (!parseResult.success) {
     return argumentError("Invalid form data");
   }
-  email = parsedData.data.email;
-  userType = parsedData.data.userType;
+  const { email, userType } = parseResult.data;
 
   const existingUser = await db.user.findFirst({ where: { email } });
   if (existingUser) {

--- a/src/app/api/invites/route.ts
+++ b/src/app/api/invites/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
     const parsedData = schema.parse(formData);
     email = parsedData.email;
     userType = parsedData.userType;
-  } catch (error) {
+  } catch {
     return argumentError("Invalid form data");
   }
 

--- a/src/app/api/invites/route.ts
+++ b/src/app/api/invites/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest } from "next/server";
+import { zfd } from "zod-form-data";
+import { auth } from "@/auth";
+import {
+  argumentError,
+  authenticationError,
+  authorizationError,
+  conflictError,
+  ok,
+} from "@/util/responses";
+import { UserType } from "@prisma/client";
+import { db } from "@/db";
+import { v4 as uuidv4 } from "uuid";
+import { sendEmail } from "@/util/email";
+import { render } from "@react-email/render";
+import UserInviteTemplate from "@/email/UserInviteTemplate";
+import { z } from "zod";
+
+const schema = zfd.formData({
+  email: zfd.text(z.string().email()),
+  userType: zfd.text(z.nativeEnum(UserType)),
+});
+
+/**
+ * Handles POST requests for creating user invites
+ * @param {NextRequest} request - The incoming request object
+ * @returns {Promise<Response>} Response indicating success or failure
+ * @throws {Response} 401 if no valid session
+ * @throws {Response} 403 if user is not SUPER_ADMIN
+ * @throws {Response} 400 if form data is invalid
+ * @throws {Response} 409 if email is already registered
+ *
+ * This endpoint:
+ * 1. Validates the user has SUPER_ADMIN privileges
+ * 2. Validates the email and userType from form data
+ * 3. Checks if email is already registered
+ * 4. Creates a new user invite with 24 hour expiration
+ * 5. Sends invite email with registration link
+ */
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session) return authenticationError("Session required");
+
+  if (session.user.type !== UserType.SUPER_ADMIN) {
+    return authorizationError("You are not allowed to create an invite");
+  }
+
+  const formData = await request.formData();
+  let email, userType;
+  try {
+    const parsedData = schema.parse(formData);
+    email = parsedData.email;
+    userType = parsedData.userType;
+  } catch (error) {
+    return argumentError("Invalid form data");
+  }
+
+  const existingUser = await db.user.findFirst({ where: { email } });
+  if (existingUser) {
+    return conflictError("Email already registered");
+  }
+
+  const token = uuidv4();
+  const expiration = new Date();
+  expiration.setDate(expiration.getDate() + 1);
+
+  await db.userInvite.create({
+    data: {
+      email,
+      token,
+      expiration,
+      userType,
+    },
+  });
+
+  const inviteUrl = `${request.nextUrl}register?token=${token}`;
+  const html = await render(UserInviteTemplate({ inviteUrl }));
+  await sendEmail(email, "Your Invite Link", html);
+
+  return ok();
+}

--- a/src/email/UserInviteTemplate.tsx
+++ b/src/email/UserInviteTemplate.tsx
@@ -1,0 +1,50 @@
+export default function Template({ inviteUrl }: { inviteUrl: string }) {
+  const styles = {
+    container: {
+      fontFamily: "Arial, sans-serif",
+      backgroundColor: "#f4f4f4",
+      padding: "20px",
+      textAlign: "center",
+    },
+    box: {
+      backgroundColor: "#ffffff",
+      borderRadius: "10px",
+      padding: "20px",
+      maxWidth: "400px",
+      margin: "0 auto",
+      boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+    },
+    header: {
+      fontSize: "24px",
+      color: "#333333",
+      marginBottom: "10px",
+    },
+    text: {
+      fontSize: "16px",
+      color: "#666666",
+      marginBottom: "20px",
+      lineHeight: "1.5",
+    },
+    button: {
+      display: "inline-block",
+      padding: "10px 20px",
+      fontSize: "16px",
+      color: "#ffffff",
+      backgroundColor: "#007BFF",
+      border: "none",
+      borderRadius: "5px",
+      textDecoration: "none",
+      cursor: "pointer",
+    },
+  };
+
+  return (
+    // @ts-expect-error idk what is wrong here, but this should be fine
+    <div style={styles.container}>
+      <div style={styles.box}>
+        <h1 style={styles.header}>Your invite link</h1>
+        <p style={styles.text}>{inviteUrl}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/test/emailMock.ts
+++ b/src/test/emailMock.ts
@@ -1,12 +1,16 @@
+import { sendEmail } from "@/util/email";
 import { jest } from "@jest/globals";
+import { mockReset } from "jest-mock-extended";
 
-const sendEmailMock = jest
-  .fn()
-  .mockImplementation(async () => Promise.resolve());
+const sendEmailMock = jest.fn<typeof sendEmail>();
 
 jest.mock("@/util/email", () => ({
   __esModule: true,
   sendEmail: sendEmailMock,
 }));
+
+beforeEach(() => {
+  mockReset(sendEmailMock);
+});
 
 export { sendEmailMock };

--- a/src/test/emailMock.ts
+++ b/src/test/emailMock.ts
@@ -2,7 +2,7 @@ import { jest } from "@jest/globals";
 
 const sendEmailMock = jest
   .fn()
-  .mockImplementation(async (to, subject, html) => Promise.resolve());
+  .mockImplementation(async () => Promise.resolve());
 
 jest.mock("@/util/email", () => ({
   __esModule: true,

--- a/src/test/emailMock.ts
+++ b/src/test/emailMock.ts
@@ -1,0 +1,13 @@
+import { jest } from "@jest/globals";
+import open from "open-html";
+
+const sendEmailMock = jest
+  .fn()
+  .mockImplementation(async (to, subject, html) => Promise.resolve());
+
+jest.mock("@/util/email", () => ({
+  __esModule: true,
+  sendEmail: sendEmailMock,
+}));
+
+export { sendEmailMock };

--- a/src/test/emailMock.ts
+++ b/src/test/emailMock.ts
@@ -1,5 +1,4 @@
 import { jest } from "@jest/globals";
-import open from "open-html";
 
 const sendEmailMock = jest
   .fn()


### PR DESCRIPTION
Resolves #5

## Success Criteria

- [x] If the request does not have a valid session, then `POST /api/invites` returns a `401` status code with JSON body `{"message": "Session required"}`
- [x] If the request session user type is not `SUPER_ADMIN`, then `POST /api/invites` returns a `403` status code with JSON body `{"message": "You are not allowed to create an invite"}`
- [x] The form data is validated using a [zod schema](https://www.npmjs.com/package/zod-form-data)
- [x] If there is already a `User` record with the given email, then `POST /api/invites` returns a `409` status code with JSON body `{"message": "Email already registered"}`
- [x] `POST /api/invites` creates a new `UserInvite` record, sends an email to the invited user, and returns a `200` status code
- [x] The sent email uses the correct origin in the register link
- [x] The `UserInvite` record will expire in **one day**
- [x] The route handler is documented with a description of its function, parameters, and responses
- [x] There is a test file that covers the success criteria