### PR TITLE
Finished partner associated unallocated item requests

### DIFF
--- a/src/app/api/partners/[partnerId]/unallocatedItemRequests/route.test.ts
+++ b/src/app/api/partners/[partnerId]/unallocatedItemRequests/route.test.ts
@@ -1,0 +1,95 @@
+import { testApiHandler } from "next-test-api-route-handler";
+import * as appHandler from "./route";
+import { expect, test } from "@jest/globals";
+import { validateSession, invalidateSession } from "@/test/util/authMockUtils";
+import { fillDbMockWithUnallocatedItemRequestsForPartnerIdFilter } from "@/test/util/dbMockUtils";
+import { dbMock } from "@/test/dbMock";
+
+test("Should return 401 for invalid session", async () => {
+  await testApiHandler({
+    params: { partnerId: "1" },
+    appHandler,
+    async test({ fetch }) {
+      invalidateSession();
+
+      const res = await fetch({ method: "GET" });
+      await expect(res.status).toBe(401);
+      const json = await res.json();
+      await expect(json).toEqual({ message: "Session required" });
+    },
+  });
+});
+
+test("Should return 403 if not STAFF, ADMIN, or SUPER_ADMIN", async () => {
+  await testApiHandler({
+    params: { partnerId: "1" },
+    appHandler,
+    async test({ fetch }) {
+      validateSession("PARTNER");
+
+      const res = await fetch({ method: "GET" });
+      await expect(res.status).toBe(403);
+      const json = await res.json();
+      await expect(json).toEqual({ message: "Unauthorized" });
+    },
+  });
+});
+
+test("Should return 200 if STAFF", async () => {
+  await testApiHandler({
+    params: { partnerId: "1" },
+    appHandler,
+    async test({ fetch }) {
+      validateSession("STAFF");
+
+      const res = await fetch({ method: "GET" });
+      await expect(res.status).toBe(200);
+    },
+  });
+});
+
+test("Should return 200 if ADMIN", async () => {
+  await testApiHandler({
+    params: { partnerId: "1" },
+    appHandler,
+    async test({ fetch }) {
+      validateSession("ADMIN");
+
+      const res = await fetch({ method: "GET" });
+      await expect(res.status).toBe(200);
+    },
+  });
+});
+
+test("Should return 200 if SUPER_ADMIN", async () => {
+  await testApiHandler({
+    params: { partnerId: "1" },
+    appHandler,
+    async test({ fetch }) {
+      validateSession("SUPER_ADMIN");
+
+      const res = await fetch({ method: "GET" });
+      await expect(res.status).toBe(200);
+    },
+  });
+});
+
+// This method doesn't have a mock db implemented such that it verifies that the only items being pulled are those associated with the partner id.
+test("Should return 200 and unallocated item requests associated with partnerId", async () => {
+  await testApiHandler({
+    params: { partnerId: "1" },
+    appHandler,
+    async test({ fetch }) {
+      validateSession("STAFF");
+
+      fillDbMockWithUnallocatedItemRequestsForPartnerIdFilter(10);
+      const expectedResponse = await dbMock.unallocatedItemRequest.findMany();
+
+      const res = await fetch({ method: "GET" });
+      expect(res.status).toBe(200);
+
+      const json = await res.json();
+      expect(json).toEqual({ unallocatedItemRequests: expectedResponse });
+    },
+  });
+});

--- a/src/app/api/partners/[partnerId]/unallocatedItemRequests/route.ts
+++ b/src/app/api/partners/[partnerId]/unallocatedItemRequests/route.ts
@@ -1,0 +1,59 @@
+import { auth } from "@/auth";
+import { db } from "@/db";
+import {
+  argumentError,
+  authenticationError,
+  authorizationError,
+} from "@/util/responses";
+import { UserType } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+interface UnallocatedItemRequestsResponse {
+  unallocatedItemRequests: {
+    id: number;
+    itemId: number;
+    quantity: number;
+    comments: string;
+  }[];
+}
+
+/**
+ * Handles GET requests to retrieve unallocated item requests that relate to a partner id.
+ * @param req - the incoming request (unused)
+ * @param params - the partner id to retrieve unallocated item requests for
+ * @returns 401 if the session is invalid
+ * @returns 403 if the user type isn't staff, admin, or super admin
+ * @returns 400 if the partner id is not an integer
+ * @returns 200 and a json response with the unallocated item requests associated with the partnerId
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ partnerId: string }> }
+) {
+  const session = await auth();
+  if (!session) return authenticationError("Session required");
+  if (!session?.user) return authenticationError("User not found");
+  if (
+    session.user.type !== UserType.STAFF &&
+    session.user.type !== UserType.ADMIN &&
+    session.user.type !== UserType.SUPER_ADMIN
+  )
+    return authorizationError("Unauthorized");
+
+  const partnerId = parseInt((await params).partnerId);
+  if (isNaN(partnerId)) return argumentError("Partner Id must be an integer");
+
+  const unallocatedItemRequests = await db.unallocatedItemRequest.findMany({
+    where: { partnerId },
+    select: {
+      id: true,
+      itemId: true,
+      quantity: true,
+      comments: true,
+    },
+  });
+
+  return NextResponse.json({
+    unallocatedItemRequests,
+  } as UnallocatedItemRequestsResponse);
+}

--- a/src/test/util/dbMockUtils.ts
+++ b/src/test/util/dbMockUtils.ts
@@ -67,7 +67,24 @@ export async function fillDbMockWithUnallocatedItemRequestsForItemIdFiltering(
       comments: "Test unallocated item request " + i,
     });
   }
+}
 
+export async function fillDbMockWithUnallocatedItemRequestsForPartnerIdFilter(
+  num: number
+) {
+  const partnerId = 1;
+  const numOfItems = 10;
+
+  const unallocatedItemRequests = [];
+  for (let i = 0; i < num; i++) {
+    unallocatedItemRequests.push({
+      id: i,
+      partnerId: partnerId,
+      itemId: Math.floor(Math.random() * numOfItems),
+      quantity: Math.floor(Math.random() * 100),
+      comments: `Test comment ${i}`,
+    });
+  }
   dbMock.unallocatedItemRequest.findMany.mockResolvedValue(
     unallocatedItemRequests
   );


### PR DESCRIPTION
## Description

Create a `GET` route handler at `/api/partners/[partnerId]/unallocatedItemRequests` that returns all `UnallocatedItemRequest` records that belong to the specified partner.

## Success Criteria

- [x] 401 if no session
- [x] 403 if not `STAFF`, `ADMIN`, or `SUPER_ADMIN`
- [x] `GET /api/partners/[partnerId]/unallocatedItemRequests` returns all `UnallocatedItemRequest` records that belong to the specified partner ID
- [x] The route handler is documented with a description of its function, parameters, and responses
- [x] There is a test file that covers the success criteria

## Checklist

- [x] The ticket is mentioned above
- [x] The changes fulfill the success criteria of the ticket
- [x] The changes were self-reviewed
- [x] A review was requested
