### PR TITLE
Ezra/309 unapprove distributions

### DIFF
--- a/src/components/DistributionTable.tsx
+++ b/src/components/DistributionTable.tsx
@@ -168,10 +168,13 @@ function OptionsButton({
       error: "Failed to approve distribution.",
     });
 
-    await promise;
+    try {
+      await promise;
+      fetchTableData();
+    } finally {
+      setIsDropdownOpen(false);
+    }
 
-    setIsDropdownOpen(false);
-    fetchTableData();
   }
   
   async function unapproveDistribution() {
@@ -188,10 +191,12 @@ function OptionsButton({
       error: "Failed to unapprove distribution.",
     });
 
-    await promise; 
-
-    setIsDropdownOpen(false); 
-    fetchTableData(); 
+    try {
+      await promise;
+      fetchTableData();
+    } finally {
+      setIsDropdownOpen(false);
+    }
   }
 
   return (

--- a/src/components/DistributionTable.tsx
+++ b/src/components/DistributionTable.tsx
@@ -7,7 +7,7 @@ import { useCallback, useRef, useState } from "react";
 import { useApiClient } from "@/hooks/useApiClient";
 import Portal from "./baseTable/Portal";
 import toast from "react-hot-toast";
-import { CheckCircle, DotsThree } from "@phosphor-icons/react";
+import { CheckCircle, DotsThree, XCircle } from "@phosphor-icons/react";
 import DistributionsGeneralItemChipGroup from "./chips/DistributionsGeneralItemChipGroup";
 import { TableDistribution } from "@/types/api/distribution.types";
 import { useUser } from "@/components/context/UserContext";
@@ -173,6 +173,26 @@ function OptionsButton({
     setIsDropdownOpen(false);
     fetchTableData();
   }
+  
+  async function unapproveDistribution() {
+    const formData = new FormData(); 
+    formData.append("pending", "true");
+
+    const promise = apiClient.patch(`/api/distributions/${distribution.id}`, {
+      body: formData,
+    });
+
+    toast.promise(promise, {
+      loading: "Unapproving distribution...", 
+      success: "Distribution unapproved!", 
+      error: "Failed to unapprove distribution.",
+    });
+
+    await promise; 
+
+    setIsDropdownOpen(false); 
+    fetchTableData(); 
+  }
 
   return (
     <div className="relative">
@@ -190,13 +210,24 @@ function OptionsButton({
         position="bottom-right"
         className="w-48 rounded-md bg-white shadow-lg ring-1 ring-black/5 py-1"
       >
-        <button
-          onClick={approveDistribution}
-          className="flex items-center w-full px-4 py-2 text-sm text-left transition-colors duration-150 hover:bg-gray-50 text-gray-900 cursor-pointer"
-        >
-          <CheckCircle size={16} className="mr-3 flex-shrink-0" />
-          <p>Approve</p>
-        </button>
+        {distribution.pending ? (
+          <button
+            onClick={approveDistribution}
+            className="flex items-center w-full px-4 py-2 text-sm text-left transition-colors duration-150 hover:bg-gray-50 text-gray-900 cursor-pointer"
+          >
+            <CheckCircle size={16} className="mr-3 flex-shrink-0" />
+            <p>Approve</p>
+          </button>
+        ) : (
+          <button
+            onClick={unapproveDistribution}
+            className="flex items-center w-full px-4 py-2 text-sm text-left transition-colors duration-150 hover:bg-gray-50 text-gray-900 cursor-pointer"
+          >
+            <XCircle size={16} className="mr-3 flex-shrink-0" />
+            <p>Unapprove</p>
+          </button>
+
+        )}
       </Portal>
     </div>
   );

--- a/src/services/allocationService.ts
+++ b/src/services/allocationService.ts
@@ -317,6 +317,11 @@ export default class AllocationService {
             "Cannot transfer items from an approved distribution. Approved distributions are locked."
           );
         }
+        if (allocation.signOffId !== null) {
+          throw new ArgumentError(
+            "Cannot transfer items that have been signed off."
+          );
+        }
       }
 
       if (update.distributionId) {

--- a/src/services/distributionService.ts
+++ b/src/services/distributionService.ts
@@ -667,6 +667,18 @@ export default class DistributionService {
       throw new NotFoundError("Distribution not found");
     }
 
+    if (data.pending === true && currentDistribution.pending === false) {
+      const signedOffCount = await db.allocation.count({
+        where: {distributionId, signOffId: { not: null} },
+      });
+
+      if (signedOffCount > 0) {
+        throw new ArgumentError(
+          "Cannot unapprove a distribution that has signed-off allocations."
+        );
+      }
+    }
+
     const updatedDistribution = await db.distribution.update({
       where: { id: distributionId },
       data,


### PR DESCRIPTION
## Description

### Resolves ticket number: #309 


### Explain what your code changes:
DistributionTable.tsx - added unapprove function and conditional button rendering 
allocationService.ts - signOffId validation in updateAllocationBatch


### List the steps you took to test your code:
Tested the unapprove button and approve button within the distributions table, making sure the conditional button is correct, making sure the status changes, and the correct toast notification pops up 

Also handling edge case where the shipments are already signed off, if they are signed off, transfers cannot occur. If this is something we should add, I can definitely look into that. 

Verified within the prisma database that transferred allocation's are correctly updating(distributionId and partnerId columns) 

Also logged into the partner account to confirm that the transferred items appear in their distributions view after approval 


<img width="2826" height="220" alt="image" src="https://github.com/user-attachments/assets/843be9e8-c220-48ea-9c97-431e329c0f5d" />
<img width="590" height="218" alt="image" src="https://github.com/user-attachments/assets/68c38804-8f90-4330-b336-fa094776173c" />

<img width="1112" height="966" alt="image" src="https://github.com/user-attachments/assets/31adf54b-1388-4d45-ad3d-7890dd70809a" />


## Checklist

- [X] The ticket is mentioned above
- [X] The changes fulfill the success criteria of the ticket
- [X] The changes were self-reviewed
- [X] A review was requested
