### PR TITLE
319 item splitting and granular allocation

### DIFF
--- a/src/app/api/generalItems/[generalItemId]/lineItems/[lineItemId]/route.ts
+++ b/src/app/api/generalItems/[generalItemId]/lineItems/[lineItemId]/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/util/errors";
 import { NextRequest, NextResponse } from "next/server";
 import { formDataToObject } from "@/util/formData";
+import { z } from "zod";
 
 const updateSchema = singleLineItemSchema.partial();
 
@@ -83,7 +84,14 @@ export async function POST(
     const { generalItemId, lineItemId} = await params; 
 
     const body = await request.json()
-    const result = await LineItemService.splitLineItem(Number(lineItemId), Number(generalItemId), Number(body.splitQuantity));
+    const splitSchema = z.object({
+      quantities: z.array(z.number().int().positive()).min(2).max(7),
+    });
+    const parsed = splitSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new Error(parsed.error.message);
+    }
+    const result = await LineItemService.splitLineItem(Number(lineItemId), Number(generalItemId), parsed.data.quantities);
 
     return NextResponse.json(result, {status: 200 });
 

--- a/src/app/api/generalItems/[generalItemId]/lineItems/[lineItemId]/route.ts
+++ b/src/app/api/generalItems/[generalItemId]/lineItems/[lineItemId]/route.ts
@@ -68,6 +68,26 @@ export async function DELETE(
 }
 
 // splits line items 
-// export async function POST(
-//   _:
-// )
+export async function POST(
+  request: NextRequest, 
+  { params }: { params: Promise <{generalItemId: string; lineItemId: string}> }
+) {
+  try {
+    const session = await auth(); 
+    if(!session?.user) {
+      throw new AuthenticationError("Session required");
+    }
+
+    UserService.checkPermission(session.user, "offerWrite");
+
+    const { generalItemId, lineItemId} = await params; 
+
+    const body = await request.json()
+    const result = await LineItemService.splitLineItem(Number(lineItemId), Number(generalItemId), Number(body.splitQuantity));
+
+    return NextResponse.json(result, {status: 200 });
+
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/generalItems/[generalItemId]/lineItems/[lineItemId]/route.ts
+++ b/src/app/api/generalItems/[generalItemId]/lineItems/[lineItemId]/route.ts
@@ -66,3 +66,8 @@ export async function DELETE(
     return errorResponse(error);
   }
 }
+
+// splits line items 
+// export async function POST(
+//   _:
+// )

--- a/src/components/chips/LineItemChipGroup.tsx
+++ b/src/components/chips/LineItemChipGroup.tsx
@@ -332,6 +332,7 @@ function LineItemChip({
                     </p>
                     <input
                       type="number"
+                      step={1}
                       min={1}
                       max={item.quantity - 1}
                       value={splitQuantity}
@@ -345,7 +346,7 @@ function LineItemChip({
                           setIsSplitting(false);
                           setSplitQuantity("");
                         }}
-                        className="rounded border border-red-500 text-red-500 px-3 py-1 hover:bg-gray-primary/10 transition-all duration-200"
+                        className="rounded border border-red-primary text-red-primary px-3 py-1 hover:bg-gray-primary/10 transition-all duration-200"
                       >
                         Cancel
                       </button>
@@ -354,6 +355,7 @@ function LineItemChip({
                         disabled={
                           isSplitLoading || 
                           !splitQuantity ||
+                          !Number.isInteger(Number(splitQuantity)) || 
                           Number(splitQuantity) <= 0 ||
                           Number(splitQuantity) >= item.quantity
                         }

--- a/src/components/chips/LineItemChipGroup.tsx
+++ b/src/components/chips/LineItemChipGroup.tsx
@@ -357,7 +357,7 @@ function LineItemChip({
                         {splitQuantities.map((qty, i) => (
                           <div key={i} className="flex items-center gap-2">
                             <label className="text-sm text-gray-primary font-normal whitespace-nowrap">
-                              Item {i + 1}:
+                              Line Item {i + 1}:
                             </label>
                             <input
                               type="number"
@@ -374,8 +374,8 @@ function LineItemChip({
                             />
                           </div>
                         ))}
-                        <p className="text-xs text-gray-primary font-normal">
-                          Sum: {splitQuantities.reduce((sum, q) => sum + (Number(q) || 0), 0)} / {item.quantity}
+                        <p className="flex justify-end text-s font-semibold text-gray-primary my-2">
+                          Total: {splitQuantities.reduce((sum, q) => sum + (Number(q) || 0), 0)} / {item.quantity}
                         </p>
                       </div>
                     )}

--- a/src/components/chips/LineItemChipGroup.tsx
+++ b/src/components/chips/LineItemChipGroup.tsx
@@ -346,7 +346,7 @@ function LineItemChip({
                           setIsSplitting(false);
                           setSplitQuantity("");
                         }}
-                        className="rounded border border-red-primary text-red-primary px-3 py-1 hover:bg-gray-primary/10 transition-all duration-200"
+                        className="rounded border border-red-primary text-red-primary px-3 py-1 hover:bg-red-primary/10 transition-all duration-200"
                       >
                         Cancel
                       </button>

--- a/src/components/chips/LineItemChipGroup.tsx
+++ b/src/components/chips/LineItemChipGroup.tsx
@@ -3,6 +3,7 @@ import { toast } from "react-hot-toast";
 import { AdvancedBaseTableHandle } from "../baseTable/AdvancedBaseTable";
 import { AllocationTableItem } from "../allocationTable/types";
 import Chip from "./Chip";
+import { useState } from "react"; 
 
 export interface PartnerDistributionSummary {
   id: number;
@@ -92,6 +93,8 @@ function LineItemChip({
   isInteractionMode?: boolean;
   readOnly?: boolean;
 }) {
+  const [isSplitting, setIsSplitting] = useState(false); 
+  const [splitQuantity, setSplitQuantity] = useState("");
   const { apiClient } = useApiClient();
 
   function updateLineItemInTable(updatedItem: Partial<typeof item>) {
@@ -101,6 +104,38 @@ function LineItemChip({
         it.id === item.id ? { ...it, ...updatedItem } : it
       ),
     }));
+  }
+
+  async function splitItem() {
+    try {
+      const response = await apiClient.post<{
+        original: {id: number; quantity: number};
+        newItem: typeof item; 
+      }>(
+        `/api/generalItems/${generalItemId}/lineItems/${item.id}`,
+        { body: JSON.stringify({ splitQuantity: Number(splitQuantity) }) }
+      );
+
+      updateItem(generalItemId, (prev) => ({
+        ...prev, 
+        items: prev.items
+          .map((it) => 
+            it.id === item.id
+              ? {...it, quantity: response.original.quantity }
+              : it
+          )
+          .concat([{
+            ...response.newItem,
+            allocation: null, 
+          }])
+      }));
+
+      toast.success("Line item split successfully!");
+      setIsSplitting(false);
+      setSplitQuantity("");
+    } catch (error) {
+      toast.error((error as Error).message || "Failed to split line item.");
+    }
   }
 
   async function unallocateItem() {
@@ -275,6 +310,57 @@ function LineItemChip({
                 </button>
               ))}
             </div>
+            {!item.allocation && !isInteractionMode && item.quantity > 1 && (
+              <div className="border-t border-gray-primary/20 mt-2 pt-2">
+                {!isSplitting ? (
+                  <button
+                    onClick={() => setIsSplitting(true)}
+                    className="w-full text-center px-2 py-1 hover:bg-blue-primary/20 border border-blue-primary rounded transition-all duration-200"
+                  >
+                    Split by Quantity
+                  </button>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    <p className="text-gray-primary font-bold mb-1">Split Item</p>
+                    <p className="text-sm text-gray-primary font-normal">
+                      Split Quantity
+                    </p>
+                    <input
+                      type="number"
+                      min={1}
+                      max={item.quantity - 1}
+                      value={splitQuantity}
+                      onChange={(e) => setSplitQuantity(e.target.value)}
+                      placeholder={`1 - ${item.quantity - 1}`}
+                      className="border border-gray-primary/20 rounded px-2 py-1 font-normal"
+                    />
+                    <div className="w-full flex justify-end gap-2">
+                      <button
+                        onClick={() => {
+                          setIsSplitting(false);
+                          setSplitQuantity("");
+                        }}
+                        className="rounded border border-red-500 text-red-500 px-3 py-1 hover:bg-gray-primary/10 transition-all duration-200"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        onClick={splitItem}
+                        disabled={
+                          !splitQuantity ||
+                          Number(splitQuantity) <= 0 ||
+                          Number(splitQuantity) >= item.quantity
+                        }
+                        className="rounded bg-blue-primary text-white px-3 py-1 disabled:opacity-50"
+                      >
+                        Split
+                      </button>
+                    </div>
+                  </div>
+                )}
+                
+              </div>
+            )}
           </div>
         )}
       />

--- a/src/components/chips/LineItemChipGroup.tsx
+++ b/src/components/chips/LineItemChipGroup.tsx
@@ -95,7 +95,8 @@ function LineItemChip({
 }) {
   const [isSplitting, setIsSplitting] = useState(false); 
   const [isSplitLoading, setIsSplitLoading] = useState(false);
-  const [splitQuantity, setSplitQuantity] = useState("");
+  const [numSplits, setNumSplits] = useState("");
+  const [splitQuantities, setSplitQuantities] = useState<string[]>([]);
   const { apiClient } = useApiClient();
 
   function updateLineItemInTable(updatedItem: Partial<typeof item>) {
@@ -111,12 +112,13 @@ function LineItemChip({
     if (isSplitLoading) return; 
     setIsSplitLoading(true);
     try {
+      const quantities = splitQuantities.map(Number);
       const response = await apiClient.post<{
         original: {id: number; quantity: number};
-        newItem: typeof item; 
+        newItem: (typeof item)[]; 
       }>(
         `/api/generalItems/${generalItemId}/lineItems/${item.id}`,
-        { body: JSON.stringify({ splitQuantity: Number(splitQuantity) }) }
+        { body: JSON.stringify({ quantities }) }
       );
 
       updateItem(generalItemId, (prev) => ({
@@ -127,15 +129,16 @@ function LineItemChip({
               ? {...it, quantity: response.original.quantity }
               : it
           )
-          .concat([{
-            ...response.newItem,
-            allocation: null, 
-          }])
+          .concat(response.newItem.map((newItem) => ({
+            ...newItem,
+            allocation: null,
+          })))
       }));
 
       toast.success("Line item split successfully!");
       setIsSplitting(false);
-      setSplitQuantity("");
+      setNumSplits("");
+      setSplitQuantities([]);
     } catch (error) {
       toast.error((error as Error).message || "Failed to split line item.");
     } finally {
@@ -326,25 +329,62 @@ function LineItemChip({
                   </button>
                 ) : (
                   <div className="flex flex-col gap-2">
-                    <p className="text-gray-primary font-bold mb-1">Split Item</p>
+                    <p className="text-gray-primary font-bold mb-1">Split Item (Total: {item.quantity})</p>
                     <p className="text-sm text-gray-primary font-normal">
-                      Split Quantity
+                      Number of Splits
                     </p>
                     <input
                       type="number"
                       step={1}
-                      min={1}
-                      max={item.quantity - 1}
-                      value={splitQuantity}
-                      onChange={(e) => setSplitQuantity(e.target.value)}
-                      placeholder={`1 - ${item.quantity - 1}`}
+                      min={2}
+                      max={7}
+                      value={numSplits}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setNumSplits(val);
+                        const n = Number(val);
+                        if (n >= 2 && n <= 7) {
+                          setSplitQuantities(Array(n).fill(""));
+                        } else {
+                          setSplitQuantities([]);
+                        }
+                      }}
+                      placeholder="2 - 7"
                       className="border border-gray-primary/20 rounded px-2 py-1 font-normal"
                     />
+                    {splitQuantities.length > 0 && (
+                      <div className="flex flex-col gap-1 mt-1">
+                        {splitQuantities.map((qty, i) => (
+                          <div key={i} className="flex items-center gap-2">
+                            <label className="text-sm text-gray-primary font-normal whitespace-nowrap">
+                              Item {i + 1}:
+                            </label>
+                            <input
+                              type="number"
+                              step={1}
+                              min={1}
+                              value={qty}
+                              onChange={(e) => {
+                                const updated = [...splitQuantities];
+                                updated[i] = e.target.value;
+                                setSplitQuantities(updated);
+                              }}
+                              placeholder="Qty"
+                              className="border border-gray-primary/20 rounded px-2 py-1 font-normal w-full"
+                            />
+                          </div>
+                        ))}
+                        <p className="text-xs text-gray-primary font-normal">
+                          Sum: {splitQuantities.reduce((sum, q) => sum + (Number(q) || 0), 0)} / {item.quantity}
+                        </p>
+                      </div>
+                    )}
                     <div className="w-full flex justify-end gap-2">
                       <button
                         onClick={() => {
                           setIsSplitting(false);
-                          setSplitQuantity("");
+                          setNumSplits("");
+                          setSplitQuantities([]);
                         }}
                         className="rounded border border-red-primary text-red-primary px-3 py-1 hover:bg-red-primary/10 transition-all duration-200"
                       >
@@ -353,11 +393,10 @@ function LineItemChip({
                       <button
                         onClick={splitItem}
                         disabled={
-                          isSplitLoading || 
-                          !splitQuantity ||
-                          !Number.isInteger(Number(splitQuantity)) || 
-                          Number(splitQuantity) <= 0 ||
-                          Number(splitQuantity) >= item.quantity
+                          isSplitLoading ||
+                          splitQuantities.length < 2 ||
+                          splitQuantities.some((q) => !q || !Number.isInteger(Number(q)) || Number(q) <= 0) ||
+                          splitQuantities.reduce((sum, q) => sum + (Number(q) || 0), 0) !== item.quantity
                         }
                         className="rounded bg-blue-primary text-white px-3 py-1 disabled:opacity-50"
                       >

--- a/src/components/chips/LineItemChipGroup.tsx
+++ b/src/components/chips/LineItemChipGroup.tsx
@@ -94,6 +94,7 @@ function LineItemChip({
   readOnly?: boolean;
 }) {
   const [isSplitting, setIsSplitting] = useState(false); 
+  const [isSplitLoading, setIsSplitLoading] = useState(false);
   const [splitQuantity, setSplitQuantity] = useState("");
   const { apiClient } = useApiClient();
 
@@ -107,6 +108,8 @@ function LineItemChip({
   }
 
   async function splitItem() {
+    if (isSplitLoading) return; 
+    setIsSplitLoading(true);
     try {
       const response = await apiClient.post<{
         original: {id: number; quantity: number};
@@ -135,6 +138,8 @@ function LineItemChip({
       setSplitQuantity("");
     } catch (error) {
       toast.error((error as Error).message || "Failed to split line item.");
+    } finally {
+      setIsSplitLoading(false);
     }
   }
 
@@ -347,6 +352,7 @@ function LineItemChip({
                       <button
                         onClick={splitItem}
                         disabled={
+                          isSplitLoading || 
                           !splitQuantity ||
                           Number(splitQuantity) <= 0 ||
                           Number(splitQuantity) >= item.quantity

--- a/src/components/chips/LineItemChipGroup.tsx
+++ b/src/components/chips/LineItemChipGroup.tsx
@@ -343,7 +343,7 @@ function LineItemChip({
                         const val = e.target.value;
                         setNumSplits(val);
                         const n = Number(val);
-                        if (n >= 2 && n <= 7) {
+                        if (Number.isInteger(n) && n >= 2 && n <= 7) {
                           setSplitQuantities(Array(n).fill(""));
                         } else {
                           setSplitQuantities([]);

--- a/src/services/lineItemService.ts
+++ b/src/services/lineItemService.ts
@@ -203,6 +203,7 @@ export class LineItemService {
 
   static async splitLineItem(lineItemId: number, generalItemId: number, splitQuantity: number) {
     return await db.$transaction(async (tx) => {
+      await tx.$queryRaw`SELECT id FROM "LineItem" WHERE id = ${lineItemId} FOR UPDATE`;
       const lineItem = await tx.lineItem.findUnique({
         where: {id: lineItemId },
         include: {

--- a/src/services/lineItemService.ts
+++ b/src/services/lineItemService.ts
@@ -201,7 +201,7 @@ export class LineItemService {
     }
   }
 
-  static async splitLineItem(lineItemId: number, generalItemId: number, splitQuantity: number) {
+  static async splitLineItem(lineItemId: number, generalItemId: number, quantities: number[]) {
     return await db.$transaction(async (tx) => {
       await tx.$queryRaw`SELECT id FROM "LineItem" WHERE id = ${lineItemId} FOR UPDATE`;
       const lineItem = await tx.lineItem.findUnique({
@@ -230,30 +230,37 @@ export class LineItemService {
       if (lineItem.allocation) {
         throw new Error("Cannot split an already allocated line item.");
       }
-      if(!Number.isInteger(splitQuantity)) {
-        throw new Error("Split quantity must be a whole number.");
+      if (quantities.length < 2 || quantities.length > 7) {
+        throw new Error("Number of splits must be between 2 and 7");
       }
-      if (splitQuantity <= 0 || splitQuantity >= lineItem.quantity) {
-        throw new Error(`Split quantity must be between 1 and ${lineItem.quantity - 1}`);
+      if (quantities.some((q) => !Number.isInteger(q) || q <= 0)) {
+        throw new Error("All quantities must be positive whole numbers.");
+      }
+      if (quantities.reduce((sum, q) => sum + q, 0) !== lineItem.quantity) {
+        throw new Error(`Quantities must add up to ${lineItem.quantity}`);
       }
       
       const original = await tx.lineItem.update({
         where: { id: lineItemId },
-        data: { quantity: lineItem.quantity - splitQuantity }
+        data: { quantity: quantities[0] }
       });
       
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { id, allocation, generalItem, generalItemId: _gId , ...itemData } = lineItem; 
 
-      const newItem = await tx.lineItem.create({
-        data: {
-          ...itemData, 
-          quantity: splitQuantity, 
-          generalItem: {
-            connect: { id: generalItemId },
-          },
-        },
-      });
+      const newItem = await Promise.all(
+        quantities.slice(1).map((qty) =>
+          tx.lineItem.create({
+            data: {
+              ...itemData,
+              quantity: qty,
+              generalItem: {
+                connect: { id: generalItemId },
+              },
+            },
+          })
+        )
+      );
 
       return { original, newItem };
     })

--- a/src/services/lineItemService.ts
+++ b/src/services/lineItemService.ts
@@ -229,6 +229,9 @@ export class LineItemService {
       if (lineItem.allocation) {
         throw new Error("Cannot split an already allocated line item.");
       }
+      if(!Number.isInteger(splitQuantity)) {
+        throw new Error("Split quantity must be a whole number.");
+      }
       if (splitQuantity <= 0 || splitQuantity >= lineItem.quantity) {
         throw new Error(`Split quantity must be between 1 and ${lineItem.quantity - 1}`);
       }

--- a/src/services/lineItemService.ts
+++ b/src/services/lineItemService.ts
@@ -201,6 +201,60 @@ export class LineItemService {
     }
   }
 
+  static async splitLineItem(lineItemId: number, generalItemId: number, splitQuantity: number) {
+    return await db.$transaction(async (tx) => {
+      const lineItem = await tx.lineItem.findUnique({
+        where: {id: lineItemId },
+        include: {
+          generalItem: {
+            include: {
+              donorOffer: {
+                select: { state: true }
+              }
+            }
+          },
+          allocation: true
+        }
+      });
+
+      if (!lineItem) {
+        throw new Error(`Line item with ID ${lineItemId} does not exist.`);
+      }
+      if (lineItem.generalItemId !== generalItemId) {
+        throw new Error("Line item does not belong to this general item.");
+      }
+      if (lineItem.generalItem?.donorOffer?.state === "ARCHIVED") {
+        throw new Error("Cannot split line items for archived donor offers.");
+      }
+      if (lineItem.allocation) {
+        throw new Error("Cannot split an already allocated line item.");
+      }
+      if (splitQuantity <= 0 || splitQuantity >= lineItem.quantity) {
+        throw new Error(`Split quantity must be between 1 and ${lineItem.quantity - 1}`);
+      }
+      
+      const original = await tx.lineItem.update({
+        where: { id: lineItemId },
+        data: { quantity: lineItem.quantity - splitQuantity }
+      });
+      
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { id, allocation, generalItem, generalItemId: _gId , ...itemData } = lineItem; 
+
+      const newItem = await tx.lineItem.create({
+        data: {
+          ...itemData, 
+          quantity: splitQuantity, 
+          generalItem: {
+            connect: { id: generalItemId },
+          },
+        },
+      });
+
+      return { original, newItem };
+    })
+  }
+
   static async getAllItems(
     filters?: Filters,
     page?: number,


### PR DESCRIPTION
## Description

Resolves ticket number: #319 


### Explain what your code changes:
- lineItemService.ts: 
- Added method to split line item with $transaction 
- Contains validations to make sure the item is valid 

[lineItemId]/route.ts: 
- Added POST request following the other api routes and calling the new method (splitLineItem()) in lineItemservices.ts


LineItemChipGroup.tsx: 
- Added Split by Quantity button, under the conditions taht the item is unallocated and has quantity > 1
- Sending messages via toast 
- Added 'isSplitLoading' to prevent race conditions from double clicking(would previously add twice if accidentally cliekd twice in rapid succession) 




### List the steps you took to test your code:
Added mock information into Allocation View and tested splits
<img width="448" height="323" alt="image" src="https://github.com/user-attachments/assets/6247129e-b310-48cd-bbec-277a01808e0e" />
- Added prevention of splitting decimals 
- Fixed race condition by locking button once clicked / isLoading 

## Checklist

- [X] The ticket is mentioned above
- [X] The changes fulfill the success criteria of the ticket
- [X] The changes were self-reviewed
- [X] A review was requested
