### PR TITLE
ezra/325-negating-duplicate-offer-error 

### DIFF
--- a/src/app/donorOffers/[donorOfferId]/finalize/page.tsx
+++ b/src/app/donorOffers/[donorOfferId]/finalize/page.tsx
@@ -211,7 +211,7 @@ export default function FinalizeDonorOfferPage() {
         onReset={resetUpload}
       />
 
-      {errors && errors.length > 0 && <ErrorDisplay errors={errors} />}
+      {errors && errors.length > 0 && !fileErrorMessage && <ErrorDisplay errors={errors} />}
 
       {preview && <PreviewTable final={true} data={previewData} />}
 

--- a/src/app/donorOffers/create/page.tsx
+++ b/src/app/donorOffers/create/page.tsx
@@ -218,7 +218,7 @@ export default function CreateDonorOfferPage() {
         onReset={resetUpload}
       />
 
-      {errors && errors.length > 0 && <ErrorDisplay errors={errors} />}
+      {errors && errors.length > 0 && !fileErrorMessage && <ErrorDisplay errors={errors} />}
 
       {preview && <PreviewTable final={false} data={data} />}
 

--- a/src/screens/AdminDistributionsScreen.tsx
+++ b/src/screens/AdminDistributionsScreen.tsx
@@ -11,7 +11,7 @@ import { useRouter } from "next/navigation";
 enum DistributionTab {
   DISTRIBUTIONS = "Distributions",
   SHIPMENTS = "Shipments",
-  SIGNOFFS = "Sign-offs"
+  SIGNOFFS = "Completed Sign-offs"
 }
 
 export default function AdminDistributionsScreen() {


### PR DESCRIPTION
## Description

Resolves ticket number: #325 


Explain what your code changes: There are two sources where errors are stored within the create/page.tsx and finalize/page.tsx. It is ultimately stored within ErrorDisplay and fileErrorMessage. Because we want to keep the error display(the error at the top), just negated the fileErrorMessage. 

On creation: 
<img width="1411" height="690" alt="image" src="https://github.com/user-attachments/assets/f40f1d2b-b255-4317-a187-46671ce90c86" />

On finalization: 
List the steps you took to test your code: Manually uploading invalid csv files on both creation and finalization 
<img width="1389" height="605" alt="image" src="https://github.com/user-attachments/assets/ce26814f-8ebe-4fec-9278-58eaee0d651a" />

Also changed the "Sign Offs" to "Completed Sign Offs" in a following commit 

## Checklist

- [X] The ticket is mentioned above
- [X] The changes fulfill the success criteria of the ticket
- [X] The changes were self-reviewed
- [X] A review was requested
