### PR TITLE
Ezra/321 request fulfillment and history dashboard

### DIFF
--- a/src/app/adminRequests/page.tsx
+++ b/src/app/adminRequests/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React from "react";
+import { useSession } from "next-auth/react";
+import { redirect } from "next/navigation";
+import AdminRequestsScreen from "@/screens/AdminRequestsScreen";
+import { hasPermission } from "@/lib/userUtils";
+
+export default function AdminRequestsPage() {
+  const { data: session } = useSession();
+
+  if (!session?.user?.type) {
+    redirect("/signIn");
+  }
+
+  if (session.user.type === "PARTNER") {
+    redirect("/");
+  }
+
+  if (hasPermission(session.user, "requestRead")) {
+    return <AdminRequestsScreen />;
+  }
+
+  redirect("/");
+}

--- a/src/app/api/adminRequests/route.ts
+++ b/src/app/api/adminRequests/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { auth } from "@/auth";
+import UserService from "@/services/userService";
+import AdminRequestsService from "@/services/adminRequestsService";
+import {
+  ArgumentError,
+  AuthenticationError,
+  errorResponse,
+} from "@/util/errors";
+import { tableParamsSchema } from "@/schema/tableParams";
+
+const statusSchema = z.enum(["current", "past"]);
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      throw new AuthenticationError("Session required");
+    }
+
+    if (session.user.type === "PARTNER") {
+      throw new AuthenticationError("Partners cannot access admin requests");
+    }
+
+    UserService.checkPermission(session.user, "requestRead");
+
+    const url = new URL(request.url);
+
+    const parsedStatus = statusSchema.safeParse(url.searchParams.get("status"));
+    if (!parsedStatus.success) {
+      throw new ArgumentError("Invalid or missing status parameter");
+    }
+
+    const parsed = tableParamsSchema.safeParse({
+      pageSize: Number(url.searchParams.get("pageSize")),
+      page: Number(url.searchParams.get("page")),
+      filters: url.searchParams.get("filters"),
+    });
+
+    if (!parsed.success) {
+      throw new ArgumentError(parsed.error.message);
+    }
+
+    const page = parsed.data.page ?? undefined;
+    const pageSize = parsed.data.pageSize ?? undefined;
+    const filters = parsed.data.filters ?? undefined;
+
+    if (parsedStatus.data === "current") {
+      const result = await AdminRequestsService.getCurrentRequests(
+        filters,
+        page,
+        pageSize
+      );
+      return NextResponse.json(result);
+    }
+
+    const result = await AdminRequestsService.getPastRequests(
+      filters,
+      page,
+      pageSize
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/components/CurrentRequestsTable.tsx
+++ b/src/components/CurrentRequestsTable.tsx
@@ -1,0 +1,99 @@
+import AdvancedBaseTable, {
+  AdvancedBaseTableHandle,
+  FilterList,
+  ColumnDefinition,
+} from "./baseTable/AdvancedBaseTable";
+import { useCallback, useRef } from "react";
+import { useApiClient } from "@/hooks/useApiClient";
+import {
+  CurrentRequestGroup,
+  CurrentRequestsResponse,
+} from "@/types/api/adminRequests.types";
+
+export default function CurrentRequestsTable() {
+  const { apiClient } = useApiClient();
+  const tableRef = useRef<AdvancedBaseTableHandle<CurrentRequestGroup>>(null);
+
+  const fetchTableData = useCallback(
+    async (
+      pageSize: number,
+      page: number,
+      filters: FilterList<CurrentRequestGroup>
+    ) => {
+      const searchParams = new URLSearchParams({
+        status: "current",
+        page: page.toString(),
+        pageSize: pageSize.toString(),
+        filters: JSON.stringify(filters),
+      });
+      const res = await apiClient.get<CurrentRequestsResponse>(
+        `/api/adminRequests?${searchParams.toString()}`
+      );
+
+      return {
+        data: res.data,
+        total: res.total,
+      };
+    },
+    [apiClient]
+  );
+
+  const columns = [
+    {
+      id: "date",
+      header: "Date Requested",
+      filterType: "date",
+      cell: (row) =>
+        new Date(row.date).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        }),
+    },
+    {
+      id: "partnerName",
+      header: "Partner Name",
+      filterType: "string",
+      cell: (row) => row.partner.name,
+    },
+    {
+      id: "itemCount",
+      header: "Items Requested",
+      filterable: false,
+      cell: (row) => row.items.length,
+    },
+  ] as ColumnDefinition<CurrentRequestGroup>[];
+
+  return (
+    <AdvancedBaseTable
+      ref={tableRef}
+      columns={columns}
+      fetchFn={fetchTableData}
+      rowId={(row) => `${new Date(row.date).getTime()}|${row.partner.id}`}
+      emptyState="No current requests found."
+      rowBody={(group) => (
+        <div className="bg-blue-light/30 p-4">
+          <table className="w-full">
+            <thead>
+              <tr className="text-left text-sm text-gray-primary/70">
+                <th className="px-4 py-2 font-medium">Item Requested</th>
+                <th className="px-4 py-2 font-medium">Quantity Requested</th>
+              </tr>
+            </thead>
+            <tbody>
+              {group.items.map((item) => (
+                <tr
+                  key={item.requestId}
+                  className="border-t border-blue-primary/10"
+                >
+                  <td className="px-4 py-2">{item.title}</td>
+                  <td className="px-4 py-2">{item.quantityRequested}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    />
+  );
+}

--- a/src/components/NavBarLayout.tsx
+++ b/src/components/NavBarLayout.tsx
@@ -13,6 +13,7 @@ import {
   Chat,
   SignOut,
   ArrowClockwise,
+  Notebook,
 } from "@phosphor-icons/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -114,6 +115,8 @@ function NavLinks({
     "archivedRead",
     "offerWrite",
   ]);
+  const canViewAdminRequests =
+    !isPartnerUser && hasPermission(user, "requestRead");
   const canViewWishlists = isPartnerUser || hasPermission(user, "wishlistRead");
   const canViewDistributions = hasAnyPermission(user, [
     "distributionRead",
@@ -150,6 +153,13 @@ function NavLinks({
           href="/donorOffers"
           label="Donor Offers"
           icon={<HandHeart size={22} />}
+        />
+      )}
+      {canViewAdminRequests && (
+        <NavLink
+          href="/adminRequests"
+          label="Requests"
+          icon={<Notebook size={22} />}
         />
       )}
       {isPartnerUser && (

--- a/src/components/PastRequestsTable.tsx
+++ b/src/components/PastRequestsTable.tsx
@@ -1,0 +1,101 @@
+import AdvancedBaseTable, {
+  AdvancedBaseTableHandle,
+  FilterList,
+  ColumnDefinition,
+} from "./baseTable/AdvancedBaseTable";
+import { useCallback, useRef } from "react";
+import { useApiClient } from "@/hooks/useApiClient";
+import {
+  PastRequestGroup,
+  PastRequestsResponse,
+} from "@/types/api/adminRequests.types";
+
+export default function PastRequestsTable() {
+  const { apiClient } = useApiClient();
+  const tableRef = useRef<AdvancedBaseTableHandle<PastRequestGroup>>(null);
+
+  const fetchTableData = useCallback(
+    async (
+      pageSize: number,
+      page: number,
+      filters: FilterList<PastRequestGroup>
+    ) => {
+      const searchParams = new URLSearchParams({
+        status: "past",
+        page: page.toString(),
+        pageSize: pageSize.toString(),
+        filters: JSON.stringify(filters),
+      });
+      const res = await apiClient.get<PastRequestsResponse>(
+        `/api/adminRequests?${searchParams.toString()}`
+      );
+
+      return {
+        data: res.data,
+        total: res.total,
+      };
+    },
+    [apiClient]
+  );
+
+  const columns = [
+    {
+      id: "date",
+      header: "Date Fulfilled/Dropped",
+      filterType: "date",
+      cell: (row) =>
+        new Date(row.date).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        }),
+    },
+    {
+      id: "partnerName",
+      header: "Partner Name",
+      filterType: "string",
+      cell: (row) => row.partner.name,
+    },
+    {
+      id: "itemCount",
+      header: "Items Requested",
+      filterable: false,
+      cell: (row) => row.items.length,
+    },
+  ] as ColumnDefinition<PastRequestGroup>[];
+
+  return (
+    <AdvancedBaseTable
+      ref={tableRef}
+      columns={columns}
+      fetchFn={fetchTableData}
+      rowId={(row) => `${new Date(row.date).getTime()}|${row.partner.id}`}
+      emptyState="No past requests found."
+      rowBody={(group) => (
+        <div className="bg-blue-light/30 p-4">
+          <table className="w-full">
+            <thead>
+              <tr className="text-left text-sm text-gray-primary/70">
+                <th className="px-4 py-2 font-medium">Item Requested</th>
+                <th className="px-4 py-2 font-medium">Quantity Requested</th>
+                <th className="px-4 py-2 font-medium">Quantity Fulfilled</th>
+              </tr>
+            </thead>
+            <tbody>
+              {group.items.map((item) => (
+                <tr
+                  key={item.requestId}
+                  className="border-t border-blue-primary/10"
+                >
+                  <td className="px-4 py-2">{item.title}</td>
+                  <td className="px-4 py-2">{item.quantityRequested}</td>
+                  <td className="px-4 py-2">{item.quantityFulfilled}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    />
+  );
+}

--- a/src/screens/AdminRequestsScreen.tsx
+++ b/src/screens/AdminRequestsScreen.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import CurrentRequestsTable from "@/components/CurrentRequestsTable";
+import PastRequestsTable from "@/components/PastRequestsTable";
+import { useUser } from "@/components/context/UserContext";
+import { hasPermission } from "@/lib/userUtils";
+import { useRouter } from "next/navigation";
+
+enum RequestsTab {
+  CURRENT = "Current Partner Requests",
+  PAST = "Past Partner Requests",
+}
+
+export default function AdminRequestsScreen() {
+  const { user } = useUser();
+  const router = useRouter();
+  const canViewRequests = hasPermission(user, "requestRead");
+
+  const availableTabs = useMemo(
+    () =>
+      [
+        canViewRequests ? RequestsTab.CURRENT : null,
+        canViewRequests ? RequestsTab.PAST : null,
+      ].filter(Boolean) as RequestsTab[],
+    [canViewRequests]
+  );
+
+  const [activeTab, setActiveTab] = useState<string>(availableTabs[0] ?? "");
+
+  useEffect(() => {
+    if (availableTabs.length === 0) {
+      router.replace("/");
+      return;
+    }
+    if (!availableTabs.includes(activeTab as RequestsTab)) {
+      setActiveTab(availableTabs[0]);
+    }
+  }, [activeTab, availableTabs, router]);
+
+  if (availableTabs.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <h1 className="text-2xl font-semibold text-gray-primary">Requests</h1>
+
+      <div className="flex space-x-4 mt-6 border-b-2 border-gray-primary border-opacity-10">
+        {availableTabs.map((tab) => (
+          <button
+            key={tab}
+            data-active={activeTab === tab}
+            className="px-2 py-1 text-md font-medium text-gray-primary text-opacity-70 relative -mb-px transition-colors focus:outline-none data-[active=true]:border-b-2 data-[active=true]:border-gray-primary data-[active=true]:bottom-[-1px] data-[active=true]:text-opacity-100"
+            onClick={() => setActiveTab(tab)}
+          >
+            <div className="hover:bg-gray-100 px-2 py-1 rounded">{tab}</div>
+          </button>
+        ))}
+      </div>
+
+      {activeTab === RequestsTab.CURRENT && canViewRequests && (
+        <CurrentRequestsTable />
+      )}
+      {activeTab === RequestsTab.PAST && canViewRequests && (
+        <PastRequestsTable />
+      )}
+    </>
+  );
+}

--- a/src/services/adminRequestsService.ts
+++ b/src/services/adminRequestsService.ts
@@ -220,7 +220,10 @@ function classifyRequest(request: RequestWithRelations): ClassifiedRequest {
   );
   const donorOffer = request.generalItem.donorOffer;
 
-  if (request.finalQuantity === 0) {
+  if (
+    request.finalQuantity === 0 &&
+    donorOffer.state !== DonorOfferState.UNFINALIZED
+  ) {
     return {
       bucket: "past",
       signedOffQuantity,
@@ -228,7 +231,10 @@ function classifyRequest(request: RequestWithRelations): ClassifiedRequest {
     };
   }
 
-  if (signedOffQuantity >= request.finalQuantity) {
+  if (
+    request.finalQuantity > 0 &&
+    signedOffQuantity >= request.finalQuantity
+  ) {
     const dateFulfilled = computeDateFulfilled(
       request.generalItem.items,
       request.partnerId,
@@ -243,7 +249,7 @@ function classifyRequest(request: RequestWithRelations): ClassifiedRequest {
 
   if (
     donorOffer.state === DonorOfferState.ARCHIVED &&
-    signedOffQuantity < request.quantity
+    signedOffQuantity < request.finalQuantity
   ) {
     return {
       bucket: "past",

--- a/src/services/adminRequestsService.ts
+++ b/src/services/adminRequestsService.ts
@@ -1,0 +1,355 @@
+import { db } from "@/db";
+import { DonorOfferState, Prisma } from "@prisma/client";
+import { Filters } from "@/types/api/filter.types";
+import {
+  CurrentRequestGroup,
+  CurrentRequestsResponse,
+  PastRequestGroup,
+  PastRequestItem,
+  PastRequestsResponse,
+} from "@/types/api/adminRequests.types";
+
+const requestInclude = {
+  partner: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+  generalItem: {
+    include: {
+      donorOffer: {
+        select: {
+          state: true,
+          archivedAt: true,
+        },
+      },
+      items: {
+        select: {
+          id: true,
+          quantity: true,
+          allocation: {
+            select: {
+              partnerId: true,
+              signOffId: true,
+              signOff: {
+                select: {
+                  id: true,
+                  date: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} satisfies Prisma.GeneralItemRequestInclude;
+
+type RequestWithRelations = Prisma.GeneralItemRequestGetPayload<{
+  include: typeof requestInclude;
+}>;
+
+type ClassifiedRequest =
+  | { bucket: "current"; signedOffQuantity: number }
+  | {
+      bucket: "past";
+      signedOffQuantity: number;
+      dateFulfilledOrDropped: Date;
+    };
+
+export default class AdminRequestsService {
+  static async getCurrentRequests(
+    filters?: Filters,
+    page?: number,
+    pageSize?: number
+  ): Promise<CurrentRequestsResponse> {
+    const where = buildCurrentWhere(filters);
+
+    const requests = await db.generalItemRequest.findMany({
+      where,
+      include: requestInclude,
+    });
+
+    const currentRequests = requests.filter(
+      (request) => classifyRequest(request).bucket === "current"
+    );
+
+    const groupsMap = new Map<string, CurrentRequestGroup>();
+    for (const request of currentRequests) {
+      const key = makeGroupKey(request.createdAt, request.partnerId);
+      let group = groupsMap.get(key);
+      if (!group) {
+        group = {
+          date: request.createdAt,
+          partner: {
+            id: request.partner.id,
+            name: request.partner.name,
+          },
+          items: [],
+        };
+        groupsMap.set(key, group);
+      }
+      group.items.push({
+        requestId: request.id,
+        title: request.generalItem.title,
+        quantityRequested: request.quantity,
+      });
+    }
+
+    const sortedGroups = Array.from(groupsMap.values()).sort(
+      (a, b) => b.date.getTime() - a.date.getTime()
+    );
+
+    const total = sortedGroups.length;
+    const paginated = paginate(sortedGroups, page, pageSize);
+
+    return { data: paginated, total };
+  }
+
+  static async getPastRequests(
+    filters?: Filters,
+    page?: number,
+    pageSize?: number
+  ): Promise<PastRequestsResponse> {
+    const where = buildPartnerNameWhere(filters);
+
+    const requests = await db.generalItemRequest.findMany({
+      where,
+      include: requestInclude,
+    });
+
+    type EnrichedPastRequest = {
+      request: RequestWithRelations;
+      signedOffQuantity: number;
+      dateFulfilledOrDropped: Date;
+    };
+
+    const pastRequests: EnrichedPastRequest[] = [];
+    for (const request of requests) {
+      const classification = classifyRequest(request);
+      if (classification.bucket !== "past") continue;
+      pastRequests.push({
+        request,
+        signedOffQuantity: classification.signedOffQuantity,
+        dateFulfilledOrDropped: classification.dateFulfilledOrDropped,
+      });
+    }
+
+    const dateFiltered = applyDateFilter(
+      pastRequests,
+      (entry) => entry.dateFulfilledOrDropped,
+      filters
+    );
+
+    const groupsMap = new Map<string, PastRequestGroup>();
+    for (const entry of dateFiltered) {
+      const { request, signedOffQuantity, dateFulfilledOrDropped } = entry;
+      const key = makeGroupKey(dateFulfilledOrDropped, request.partnerId);
+      let group = groupsMap.get(key);
+      if (!group) {
+        group = {
+          date: dateFulfilledOrDropped,
+          partner: {
+            id: request.partner.id,
+            name: request.partner.name,
+          },
+          items: [],
+        };
+        groupsMap.set(key, group);
+      }
+      const item: PastRequestItem = {
+        requestId: request.id,
+        title: request.generalItem.title,
+        quantityRequested: request.quantity,
+        quantityFulfilled: signedOffQuantity,
+      };
+      group.items.push(item);
+    }
+
+    const sortedGroups = Array.from(groupsMap.values()).sort(
+      (a, b) => b.date.getTime() - a.date.getTime()
+    );
+
+    const total = sortedGroups.length;
+    const paginated = paginate(sortedGroups, page, pageSize);
+
+    return { data: paginated, total };
+  }
+}
+
+
+function buildPartnerNameWhere(
+  filters?: Filters
+): Prisma.GeneralItemRequestWhereInput {
+  const where: Prisma.GeneralItemRequestWhereInput = {};
+
+  const partnerNameFilter = filters?.partnerName;
+  if (partnerNameFilter?.type === "string" && partnerNameFilter.value) {
+    where.partner = {
+      name: {
+        contains: partnerNameFilter.value,
+        mode: "insensitive",
+      },
+    };
+  }
+
+  return where;
+}
+
+function buildCurrentWhere(
+  filters?: Filters
+): Prisma.GeneralItemRequestWhereInput {
+  const where = buildPartnerNameWhere(filters);
+
+  const dateFilter = filters?.date;
+  if (dateFilter?.type === "date") {
+    where.createdAt = {
+      gte: new Date(dateFilter.gte),
+      ...(dateFilter.lte ? { lte: new Date(dateFilter.lte) } : {}),
+    };
+  }
+
+  return where;
+}
+
+function classifyRequest(request: RequestWithRelations): ClassifiedRequest {
+  const signedOffQuantity = computeSignedOffQuantity(
+    request.generalItem.items,
+    request.partnerId
+  );
+  const donorOffer = request.generalItem.donorOffer;
+
+  if (request.finalQuantity === 0) {
+    return {
+      bucket: "past",
+      signedOffQuantity,
+      dateFulfilledOrDropped: donorOffer.archivedAt ?? request.createdAt,
+    };
+  }
+
+  if (signedOffQuantity >= request.finalQuantity) {
+    const dateFulfilled = computeDateFulfilled(
+      request.generalItem.items,
+      request.partnerId,
+      request.finalQuantity
+    );
+    return {
+      bucket: "past",
+      signedOffQuantity,
+      dateFulfilledOrDropped: dateFulfilled ?? request.createdAt,
+    };
+  }
+
+  if (
+    donorOffer.state === DonorOfferState.ARCHIVED &&
+    signedOffQuantity < request.quantity
+  ) {
+    return {
+      bucket: "past",
+      signedOffQuantity,
+      dateFulfilledOrDropped: donorOffer.archivedAt ?? request.createdAt,
+    };
+  }
+
+  return { bucket: "current", signedOffQuantity };
+}
+
+function computeSignedOffQuantity(
+  lineItems: Array<{
+    quantity: number;
+    allocation: {
+      partnerId: number | null;
+      signOffId: number | null;
+    } | null;
+  }>,
+  partnerId: number
+): number {
+  let total = 0;
+
+  for (const lineItem of lineItems) {
+    const alloc = lineItem.allocation;
+    if (
+      alloc != null &&
+      alloc.partnerId === partnerId &&
+      alloc.signOffId != null
+    ) {
+      total += lineItem.quantity;
+    }
+  }
+
+  return total;
+}
+
+function computeDateFulfilled(
+  lineItems: Array<{
+    quantity: number;
+    allocation: {
+      partnerId: number | null;
+      signOff: { id: number; date: Date } | null;
+    } | null;
+  }>,
+  partnerId: number,
+  finalQuantity: number
+): Date | null {
+  const signedDeliveries: Array<{ date: Date; quantity: number }> = [];
+
+  for (const lineItem of lineItems) {
+    const alloc = lineItem.allocation;
+    if (
+      alloc != null &&
+      alloc.partnerId === partnerId &&
+      alloc.signOff != null
+    ) {
+      signedDeliveries.push({
+        date: alloc.signOff.date,
+        quantity: lineItem.quantity,
+      });
+    }
+  }
+
+  signedDeliveries.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  let runningTotal = 0;
+  for (const delivery of signedDeliveries) {
+    runningTotal += delivery.quantity;
+    if (runningTotal >= finalQuantity) {
+      return delivery.date;
+    }
+  }
+
+  return null;
+}
+
+function makeGroupKey(date: Date, partnerId: number): string {
+  return `${date.toISOString().slice(0, 10)}|${partnerId}`;
+}
+
+function paginate<T>(items: T[], page?: number, pageSize?: number): T[] {
+  if (!page || !pageSize) {
+    return items;
+  }
+  const start = (page - 1) * pageSize;
+  return items.slice(start, start + pageSize);
+}
+
+function applyDateFilter<T>(
+  items: T[],
+  getDate: (item: T) => Date,
+  filters?: Filters
+): T[] {
+  const dateFilter = filters?.date;
+  if (!dateFilter || dateFilter.type !== "date") {
+    return items;
+  }
+
+  const gte = new Date(dateFilter.gte);
+  const lte = dateFilter.lte ? new Date(dateFilter.lte) : null;
+
+  return items.filter((item) => {
+    const date = getDate(item);
+    if (date < gte) return false;
+    if (lte && date > lte) return false;
+    return true;
+  });
+}

--- a/src/types/api/adminRequests.types.ts
+++ b/src/types/api/adminRequests.types.ts
@@ -1,0 +1,40 @@
+export interface CurrentRequestItem {
+  requestId: number; 
+  title: string; 
+  quantityRequested: number; 
+}
+
+export interface CurrentRequestGroup {
+  date: Date; 
+  partner: {
+    id: number; 
+    name: string;
+  };
+  items: CurrentRequestItem[];
+}
+
+export interface CurrentRequestsResponse {
+  data: CurrentRequestGroup[];
+  total: number; 
+}
+
+export interface PastRequestItem {
+  requestId: number; 
+  title: string; 
+  quantityRequested: number;
+  quantityFulfilled: number; 
+}
+
+export interface PastRequestGroup {
+  date: Date; 
+  partner: {
+    id: number; 
+    name: string;
+  };
+  items: PastRequestItem[];
+}
+
+export interface PastRequestsResponse {
+  data: PastRequestGroup[];
+  total: number; 
+}


### PR DESCRIPTION
## Description

Resolves ticket number: #321 


Explain what your code changes:
Added an admin side Requests dashboard with Current and Past tabs 
Backend: 
services/adminRequestsService.ts - classifies request at Current or Past, groups by date + partner 
app/api/adminRequests/route.ts - receives GET requests from the frontend, checks staff permissions, and asks the service for current or past data 
types/api/adminRequests.types.ts -  defines the shape of the data the API sends back to the frontend tables 

Frontend: 
app/adminRequests/page.tsx - auth gatekeeper page 
screens/AdminRequestsScreen.tsx - main page  with Current / Past tab switcher 
components/CurrentRequestsTable.tsx - page for the tab with Current tab switchers 
component/PastRequestsTable.tsx - page for tab with past tab switchers 
components/NavBarLayout.tsx - new sidebar link added 


List the steps you took to test your code:

## Checklist

- [X] The ticket is mentioned above
- [X] The changes fulfill the success criteria of the ticket
- [X] The changes were self-reviewed
- [X] A review was requested
