### PR TITLE
working page redirection

### DIFF
--- a/src/app/donorOffers/[donorOfferId]/page.tsx
+++ b/src/app/donorOffers/[donorOfferId]/page.tsx
@@ -20,7 +20,7 @@ export default function DonorOfferDetailsPage() {
 
   // Partners should use the unified items screen at /items instead
   if (isPartner(session.user.type)) {
-    redirect("/");
+    redirect("/items");
   }
 
   const { data, isLoading } = useFetch<{

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import Joyride, { 
+import { 
+  Joyride, 
   Step,
   CallBackProps,
   STATUS,

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { 
-  Joyride, 
+import Joyride, { 
   Step,
   CallBackProps,
   STATUS,


### PR DESCRIPTION
## Description

Resolves ticket number: #278 


Explain what your code changes:
Now, when clicking "View the Donor Offer" once a notification is made, the screen redirects correctly to the items tab instead of the distributions tab (from the partners' end).

List the steps you took to test your code:
I signed into both the partner1 and partner2 accounts to make sure both redirected correctly to the items page.

## Checklist

- [x] The ticket is mentioned above
- [x] The changes fulfill the success criteria of the ticket
- [x] The changes were self-reviewed
- [x] A review was requested
