### PR TITLE
generate summary button replaced with tooltip if item count isn't met

### DIFF
--- a/src/screens/Wishlist/AdminWishlistScreen.tsx
+++ b/src/screens/Wishlist/AdminWishlistScreen.tsx
@@ -5,14 +5,15 @@ import AdvancedBaseTable, {
   FilterList,
 } from "@/components/baseTable/AdvancedBaseTable";
 import { useApiClient } from "@/hooks/useApiClient";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import WishlistSummary from "@/components/WishlistSummary";
-import { ChatTeardropText } from "@phosphor-icons/react";
+import { ChatTeardropText, Question } from "@phosphor-icons/react";
 import { Tooltip } from "react-tooltip";
 import PriorityTag from "@/components/tags/PriorityTag";
 
 export default function AdminWishlistScreen() {
   const { apiClient } = useApiClient();
+  const [totalItems, setTotalItems] = useState<number | null>(null);
 
   const fetch = useCallback(
     async (
@@ -29,6 +30,7 @@ export default function AdminWishlistScreen() {
         wishlists: (Wishlist & { partner: User })[];
         total: number;
       }>(`/api/wishlists?${searchParams}`);
+      setTotalItems(response.total);
 
       return {
         data: response.wishlists,
@@ -41,7 +43,21 @@ export default function AdminWishlistScreen() {
   return (
     <div className="pb-32">
       <h1 className="text-2xl font-bold text-gray-primary">Wishlists</h1>
-      <WishlistSummary />
+
+      {totalItems !== null && totalItems >= 10 ? <WishlistSummary/> :
+        <div className="flex justify-end -mb-10 mt-8 mr-28">
+          <Question 
+            size={20} 
+            className="text-gray-primary/60 cursor-help"
+            data-tooltip-id="wishlist-ai-info"
+            data-tooltip-content="AI Wishlist Summary is available when Wishlist contains 10 or more entries"
+          />
+          <Tooltip 
+            id="wishlist-ai-info" 
+            className="z-50 max-w-xs" 
+          />
+        </div>
+      }      
       <AdvancedBaseTable
         columns={[
           {


### PR DESCRIPTION
## Description

Resolves ticket number: #337

Explain what your code changes: The generate summary button on the wishlists page is replaced with a tooltip if item count isn't high enough to generate a summary yet

List the steps you took to test your code: visual confirmation

## Checklist

- [x ] The ticket is mentioned above
- [ x] The changes fulfill the success criteria of the ticket
- [ x] The changes were self-reviewed
- [ x] A review was requested
